### PR TITLE
Separate Firefox and Chrome deployment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,6 @@
 env:
   DIRECTORY: distribution
+  DIRECTORY_FIREFOX: distribution_firefox
 
 # FILE GENERATED WITH: npx ghat fregante/ghatemplates/webext
 # SOURCE: https://github.com/fregante/ghatemplates
@@ -46,9 +47,14 @@ jobs:
       - name: install
         run: npm ci || npm install
       - run: npm run build --if-present
+      - run: npm run build-firefox --if-present
       - name: Update extension’s meta
         run: >-
           npx dot-json@1 $DIRECTORY/manifest.json version ${{
+          needs.Version.outputs.version }}
+      - name: Update Firefox extension’s meta
+        run: >-
+          npx dot-json@1 $DIRECTORY_FIREFOX/manifest.json version ${{
           needs.Version.outputs.version }}
       - name: Submit
         run: |
@@ -57,7 +63,7 @@ jobs:
               cd $DIRECTORY && npx chrome-webstore-upload-cli@1 upload --auto-publish
               ;;
             firefox)
-              cd $DIRECTORY && npx web-ext-submit@6
+              cd $DIRECTORY_FIREFOX && npx web-ext-submit@6
               ;;
           esac
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules
 yarn.lock
 distribution
+distribution_firefox
 .parcel-cache

--- a/package.json
+++ b/package.json
@@ -2,6 +2,8 @@
     "private": true,
     "scripts": {
         "build": "parcel build source/manifest.json --no-content-hash --no-source-maps --dist-dir distribution --no-cache --detailed-report 0",
+        "build-firefox": "parcel build source/manifest.json --no-content-hash --no-source-maps --dist-dir distribution_firefox --no-cache --detailed-report 0 && npm run copy-minifest-firefox",
+        "copy-minifest-firefox": "cp source/manifest-firefox.json distribution_firefox/manifest.json",
         "lint": "run-p lint:*",
         "lint-fix": "run-p 'lint:* -- --fix'",
         "lint:css": "stylelint source/**/*.css",

--- a/source/manifest-firefox.json
+++ b/source/manifest-firefox.json
@@ -5,6 +5,12 @@
     "homepage_url": "https://guppy.co/",
     "manifest_version": 2,
     "minimum_chrome_version": "74",
+    "browser_specific_settings": {
+        "gecko": {
+            "id": "{851cf9cc-1890-4d1c-93dc-1f6baa9ef9ee}",
+            "strict_min_version": "57.0"
+        }
+    },
     "icons": {
         "128": "images/icon.png"
     },


### PR DESCRIPTION
Hi @YPCrumble, this PR is used for separating Firefox and Chrome deployment. because it has the difference between 2 manifest files.
Please help me to review.