### PR TITLE
Migrate to manifest v3

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,5 +10,5 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: cp source/js/env.example.js source/js/env.js
-      - run: npm install
-      - run: npm test
+      - run: yarn
+      - run: yarn test

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "scripts": {
-        "build": "parcel build source/manifest.json --no-content-hash --no-source-maps --dist-dir distribution --no-cache --detailed-report 0",
+        "build": "parcel build source/manifest.json --no-content-hash --no-source-maps --dist-dir distribution --no-cache --detailed-report 0 && cp source/mv3.json distribution/manifest.json",
         "build-firefox": "parcel build source/manifest.json --no-content-hash --no-source-maps --dist-dir distribution_firefox --no-cache --detailed-report 0 && npm run copy-minifest-firefox",
         "copy-minifest-firefox": "cp source/manifest-firefox.json distribution_firefox/manifest.json",
         "lint": "run-p lint:*",
@@ -44,10 +44,10 @@
         "webextension-polyfill": "^0.8.0"
     },
     "devDependencies": {
-        "@parcel/config-webextension": "^2.0.0-rc.0",
-        "@parcel/transformer-image": "^2.0.0-rc.0",
+        "@parcel/config-webextension": "^2.0.1",
+        "@parcel/transformer-image": "^2.0.1",
         "npm-run-all": "^4.1.5",
-        "parcel": "^2.0.0-rc.0",
+        "parcel": "^2.0.1",
         "stylelint": "^13.13.1",
         "stylelint-config-xo": "^0.20.0",
         "xo": "^0.44.0",

--- a/source/js/inc/account.js
+++ b/source/js/inc/account.js
@@ -1,4 +1,3 @@
-import $ from 'jquery'
 import browser from 'webextension-polyfill'
 
 import {env} from '../env.js'
@@ -7,17 +6,22 @@ import {getThisYear, getCookies} from './helpers.js'
 export async function flipUserStatus(action, userInfo) {
   if (action === 'login') {
     try {
-      const response = await $.ajax({
-        url: env.guppyApiUrl + '/api/login/',
-        type: 'POST',
-        data: {
+      const response = await fetch(env.guppyApiUrl + '/api/login/', {
+        method: 'POST',
+        mode: 'cors',
+        cache: 'no-cache',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
           username: userInfo.email,
           password: userInfo.pass,
-        },
-        dataType: 'json',
+        }),
       })
 
-      if (response.csrf_token) {
+      const data = await response.json()
+
+      if (data.csrf_token) {
         if (browser.runtime.lastError) {
           return 'fail'
         }
@@ -39,10 +43,13 @@ export async function flipUserStatus(action, userInfo) {
     }
 
     try {
-      const ajax = await $.ajax({
-        url: env.guppyApiUrl + '/logout/',
-        type: 'GET',
-        dataType: 'json',
+      const ajax = await fetch(env.guppyApiUrl + '/logout/', {
+        method: 'GET',
+        mode: 'cors',
+        cache: 'no-cache',
+        headers: {
+          'Content-Type': 'application/json',
+        },
       })
 
       if (!ajax || browser.runtime.lastError) {
@@ -91,13 +98,16 @@ export async function getAccountInfo() {
     const isSignedIn = await isUserSignedIn()
     if (isSignedIn.userStatus) {
       try {
-        const ajax = await $.ajax({
-          url: env.guppyApiUrl + '/api/account/',
-          type: 'GET',
-          dataType: 'json',
+        const ajax = await fetch(env.guppyApiUrl + '/api/account/', {
+          method: 'GET',
+          mode: 'cors',
+          cache: 'no-cache',
+          headers: {
+            'Content-Type': 'application/json',
+          },
         })
 
-        return ajax
+        return await ajax.json()
       } catch {
         // Logout
         flipUserStatus('logout', null)

--- a/source/js/inc/scraper.js
+++ b/source/js/inc/scraper.js
@@ -1,6 +1,8 @@
 import $ from 'jquery'
 import browser from 'webextension-polyfill'
 
+import {env} from '../env.js'
+
 // Crawl Google search results
 export async function googleSearch() {
   const origin = window.location.origin
@@ -13,9 +15,9 @@ export async function googleSearch() {
       $('#search a').each(function () {
         let uri = $(this).attr('href')
         if (uri) {
-          const separator = uri.includes('?') ? '&' : '?'
           // Temporary replace "&" by "<and>"
-          uri = uri + separator + 'google_search_term=' + terms.replaceAll('&', '<and>')
+          uri = env.guppyApiUrl + '/search-tracking/?url="' + uri + '"&search_term="' + terms.replaceAll('&', '<and>') + '"'
+          // Go to guppy search tracking then redirect to search result page
           $(this).attr('href', uri)
           // Remove event to fix clicking on Firefox
           $(this).prop('onmousedown', null)

--- a/source/js/popup-account.js
+++ b/source/js/popup-account.js
@@ -53,17 +53,28 @@ window.addEventListener('load', () => {
 
   // Request payout
   $('.request-payout').click(() => {
-    $.ajax({
-      url: env.guppyApiUrl + '/api/payouts/request/',
-      type: 'GET',
-      dataType: 'json',
-    }).done(() => {
-      $('.payout-message').text('Your request is sent')
-      $('.payout-message').addClass('alert-info')
-    }).fail(response => {
-      $('.payout-message').text(response.responseJSON.message)
+    fetch(env.guppyApiUrl + '/api/payouts/request/', {
+      method: 'GET',
+      mode: 'cors',
+      cache: 'no-cache',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    }).then(response => {
+      if (response.ok) {
+        $('.payout-message').text('Your request is sent')
+        $('.payout-message').addClass('alert-info')
+      } else {
+        response.json().then(data => {
+          $('.payout-message').text(data.message)
+          $('.payout-message').addClass('alert-danger')
+        })
+      }
+    }).catch(() => {
+      $('.payout-message').text('Something went wrong!')
       $('.payout-message').addClass('alert-danger')
     })
+
     $('.request-payout').prop('disabled', true)
   })
 

--- a/source/mv3.json
+++ b/source/mv3.json
@@ -1,0 +1,96 @@
+{
+  "name": "Guppy",
+  "version": "0.0.1",
+  "description": "Guppy collects any data available to us via our website, browser, and browser extensions.",
+  "homepage_url": "https://guppy.co/",
+  "manifest_version": 3,
+  "minimum_chrome_version": "74",
+  "icons": {
+    "128": "/images/icon.png"
+  },
+  "action": {
+    "default_icon": "/images/icon.png",
+    "default_popup": "/html/popup.html"
+  },
+  "web_accessible_resources": [
+    {
+      "resources": [
+        "/images/icon.png",
+        "/images/placeholder.jpg",
+        "/images/placeholder_120x240.jpg",
+        "/images/placeholder_120x600.jpg",
+        "/images/placeholder_125x125.jpg",
+        "/images/placeholder_160x600.jpg",
+        "/images/placeholder_180x150.jpg",
+        "/images/placeholder_200x200.jpg",
+        "/images/placeholder_234x60.jpg",
+        "/images/placeholder_250x250.jpg",
+        "/images/placeholder_300x1050.jpg",
+        "/images/placeholder_300x250.jpg",
+        "/images/placeholder_300x600.jpg",
+        "/images/placeholder_320x100.jpg",
+        "/images/placeholder_320x50.jpg",
+        "/images/placeholder_336x280.jpg",
+        "/images/placeholder_468x60.jpg",
+        "/images/placeholder_728x90.jpg",
+        "/images/placeholder_970x250.jpg",
+        "/images/placeholder_970x90.jpg",
+        "/js/background.js",
+        "/js/content-start.js",
+        "/js/content.js",
+        "/js/env.example.js",
+        "/js/env.js",
+        "/js/popup-account.js",
+        "/js/popup-sign-in.js",
+        "/js/popup.js",
+        "/html/popup.html",
+        "/html/popup_account.html",
+        "/html/popup_sign_in.html"
+      ],
+      "matches": [
+        "http://*/*",
+        "https://*/*"
+      ]
+    }
+  ],
+  "permissions": [
+    "storage",
+    "cookies",
+    "tabs",
+    "notifications"
+  ],
+  "host_permissions": [
+    "http://*/*",
+    "https://*/*"
+  ],
+  "content_scripts": [
+    {
+      "matches": [
+        "http://*/*",
+        "https://*/*"
+      ],
+      "js": [
+        "/js/content.js"
+      ],
+      "css": [
+        "/css/content.css"
+      ],
+      "run_at": "document_end",
+      "all_frames": true
+    },
+    {
+      "matches": [
+        "http://*/*",
+        "https://*/*"
+      ],
+      "js": [
+        "/js/content-start.js"
+      ],
+      "run_at": "document_start",
+      "all_frames": true
+    }
+  ],
+  "background": {
+    "service_worker": "js/background.js"
+  }
+}


### PR DESCRIPTION
Hi @YPCrumble, this PR is used for migrating our extension to use manifest v3 (for Chrome only, not working for Firefox).
Because `parcel` doesn't support MV3 yet, so I keep using MV2 builder and replace it with an MV3.json file.
Please help me to review.